### PR TITLE
modified to ignore 'virtualenv' artefacts and .vscode conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,11 @@ dmypy.json
 lib/bot/token.0
 
 data/images/
+
+# virtualenv additions
+bin/
+lib/python3.9/
+pyvenv.cfg
+
+# IDE configurations
+.vscode/


### PR DESCRIPTION
Set up virtualenv. The additions to .gitignore are created when you create a new virtual environment. There's also no point in tracking vscode configuration.