### PR TITLE
remove ':=' operator

### DIFF
--- a/lib/db/db.py
+++ b/lib/db/db.py
@@ -39,7 +39,8 @@ def close():
 def field(command, *values):
     cur.execute(command, tuple(values))
 
-    if (fetch := cur.fetchone()) is not None:
+    fetch = cur.fetchone()
+    if fetch is not None:
         return fetch[0]
 
 


### PR DESCRIPTION
For compatibility with older python versions.
This closes #11