### PR TITLE
Timed bot messages when a channel is idle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ pyvenv.cfg
 
 # IDE configurations
 .vscode/
+.dir-locals.el

--- a/lib/bot/__init__.py
+++ b/lib/bot/__init__.py
@@ -18,12 +18,14 @@ PREFIX = "$"
 # Avoid magic numbers
 SERVER_ID = 806626416783130674
 CHANNEL_TEST = 806950823396769883
+CHANNEL_HELP_AVAILABLE = 809099330950529085
 # If the last message sent in a channel was longer than this number of minutes,
 # the idle reminder will send the reminder
 IDLE_REMINDER_MINUTES = 5
 
 
 class Bot(BotBase):
+
     def __init__(self):
         self.PREFIX = PREFIX
         self.ready = False
@@ -44,12 +46,6 @@ class Bot(BotBase):
 
         print("running bot...")
         super().run(self.TOKEN, reconnect=True)
-
-    # Print message for scheduled job
-    async def idle_reminder(self, minutes):
-        # TODO create an embed and pass it to the function:
-        # embed = create_embed()
-        await idle_reminder(self.get_channel(CHANNEL_TEST), minutes)
 
     async def on_connect(self):
         print("bot connected!")
@@ -77,15 +73,36 @@ class Bot(BotBase):
     async def on_ready(self):
         if not self.ready:
             self.ready = True
-            # Checks every minute
-            self.scheduler.add_job(self.idle_reminder,
-                                   CronTrigger(second="0"),
-                                   [IDLE_REMINDER_MINUTES])
-            self.scheduler.start()
-
             # Set server-specific bot using server ID
             # Can leave this out for multi-server bot
             self.guild = self.get_guild(SERVER_ID)
+
+            embed_help = create_embed(title=":question: How to ask a good question?",
+                                      description="""**A minimal reproducible question** (a.k.a. a good question) should consist of the following:
+
+                                      **1. A clear problem statement.** What are you trying to do? What have you tried? What is the expected output?
+                                      **2. The smallest data set necessary to reproduce the problem.** Hint: Use `dput` and **no screenshots**.
+                                      **3. All relevant code** that everyone can just copy and paste into their R console.
+                                      **4. Proper `formatting` of code blocks and data** if you copy and paste directly.
+                                      **5. All relevant packages** needed to reproduce your problem.
+                                      **6. All relevant error messages**. Don't just say that you got an error.
+
+                                      For more details, check out: `How to ask a good question? (Detailed)`""",
+                                      colour=0xFF0000,
+                                      author="discoRd-bot",
+                                      author_icon=self.guild.icon_url,
+                                      thumbnail=self.guild.icon_url,
+                                      image=self.guild.icon_url)
+
+            print("help embed was created")
+            # Add a job to the scheduler
+            self.scheduler.add_job(idle_reminder,
+                                   CronTrigger(second="0"),
+                                   [self.get_channel(CHANNEL_HELP_AVAILABLE),
+                                    IDLE_REMINDER_MINUTES,
+                                    embed_help])
+            self.scheduler.start()
+
             print("bot ready")
 
             # Set channel_test using channel ID

--- a/lib/bot/__init__.py
+++ b/lib/bot/__init__.py
@@ -22,7 +22,7 @@ CHANNEL_HELP_AVAILABLE = 809099330950529085
 # If the last message sent in a channel was longer than this number of minutes,
 # the idle reminder will send the reminder
 IDLE_REMINDER_MINUTES = 20
-
+IDLE_REMINDER_CRON_TIMER = {"second":"0", "minute":"0,10,20,30,40,50"}
 
 class Bot(BotBase):
 
@@ -96,7 +96,7 @@ class Bot(BotBase):
 
             # Add a job to the scheduler
             self.scheduler.add_job(idle_reminder,
-                                   CronTrigger(second="0", minute="0,10,20,30,40,50"),  # every 10 minutes
+                                   CronTrigger(**IDLE_REMINDER_CRON_TIMER),  # every 10 minutes
                                    [self.get_channel(CHANNEL_HELP_AVAILABLE),
                                     IDLE_REMINDER_MINUTES,
                                     embed_help])

--- a/lib/bot/__init__.py
+++ b/lib/bot/__init__.py
@@ -21,7 +21,7 @@ CHANNEL_TEST = 806950823396769883
 CHANNEL_HELP_AVAILABLE = 809099330950529085
 # If the last message sent in a channel was longer than this number of minutes,
 # the idle reminder will send the reminder
-IDLE_REMINDER_MINUTES = 5
+IDLE_REMINDER_MINUTES = 20
 
 
 class Bot(BotBase):
@@ -96,7 +96,7 @@ class Bot(BotBase):
 
             # Add a job to the scheduler
             self.scheduler.add_job(idle_reminder,
-                                   CronTrigger(second="0"),
+                                   CronTrigger(second="0", minute="0,10,20,30,40,50"),  # every 10 minutes
                                    [self.get_channel(CHANNEL_HELP_AVAILABLE),
                                     IDLE_REMINDER_MINUTES,
                                     embed_help])

--- a/lib/bot/__init__.py
+++ b/lib/bot/__init__.py
@@ -94,7 +94,6 @@ class Bot(BotBase):
                                       thumbnail=self.guild.icon_url,
                                       image=self.guild.icon_url)
 
-            print("help embed was created")
             # Add a job to the scheduler
             self.scheduler.add_job(idle_reminder,
                                    CronTrigger(second="0"),
@@ -108,28 +107,6 @@ class Bot(BotBase):
             # Set channel_test using channel ID
             channel_test = self.get_channel(CHANNEL_TEST)
             await channel_test.send("Now online!")
-
-            # # Create and send embed to channel
-            # fields = [
-            #     ("Name1", "Value1", True),
-            #     ("Name2", "Value2", True),
-            #     ("A longer Name", "A longer Value", False)
-            # ]
-
-            # embed = create_embed(
-            #     title = "Now online!",
-            #     description = "discoRd-bot is now online!",
-            #     colour = 0xFF0000,
-            #     timestamp = datetime.utcnow(),
-            #     fields = fields,
-            #     author = "discoRd-bot",
-            #     author_icon = self.guild.icon_url,
-            #     thumbnail = self.guild.icon_url,
-            #     image = self.guild.icon_url,
-            #     footer = "testing a footer"
-            # )
-
-            # await channel_test.send(embed=embed)
 
         else:
             print("bot reconnected")

--- a/lib/bot/create_embed.py
+++ b/lib/bot/create_embed.py
@@ -1,11 +1,12 @@
 from discord import Embed
+from datetime import datetime
 
 def create_embed(
     title,
     description,
-    fields,
+    fields = None,
     colour = None,
-    timestamp = None,
+    timestamp = datetime.utcnow(),
     author = None,
     author_icon = None,
     thumbnail = None,
@@ -17,9 +18,9 @@ def create_embed(
     Args:
         title (str): Set title
         description (str): Set description
-        fields (tuple): Set fields
+        fields (list of tuples): Set fields
         colour (int, optional): Set color. Defaults to None.
-        timestamp (datetime, optional): Set timestamp. Defaults to None.
+        timestamp (datetime, optional): Set timestamp. Defaults to current time.
         author (str, optional): Set author. Defaults to None.
         author_icon (str, optional): Set author icon using image url. Defaults to None.
         thumbnail (str, optional): Set thumbnail using image url. Defaults to None.
@@ -37,8 +38,9 @@ def create_embed(
         timestamp=timestamp
     )
 
-    for name, value, inline in fields:
-        embed.add_field(name=name, value=value, inline=inline)
+    if fields is not None:
+        for name, value, inline in fields:
+            embed.add_field(name=name, value=value, inline=inline)
 
     embed.set_author(name=author, icon_url=author_icon)
     embed.set_footer(text=footer)

--- a/lib/bot/idle_reminder.py
+++ b/lib/bot/idle_reminder.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
-# TODO: Add an embed argument
-async def idle_reminder(channel, wait_minutes=5):
+
+async def idle_reminder(channel, wait_minutes, embed):
     """
     Checks if 'channel' has been idle for more than 'wait_minutes'
     minutes. If so, sends an embed to that channel.
@@ -23,7 +23,4 @@ async def idle_reminder(channel, wait_minutes=5):
     delta = now_time - last_time
 
     if delta > wait_time:
-        # await channel.send(embed = embed)
-        await channel.send("More than " + str(wait_time.seconds) +
-                           " seconds has passed " +
-                           "since the last message has been sent.")
+        await channel.send(embed=embed)

--- a/lib/bot/idle_reminder.py
+++ b/lib/bot/idle_reminder.py
@@ -16,11 +16,13 @@ async def idle_reminder(channel, wait_minutes, embed):
     """
     print("Running idle_reminder()")
 
-    now_time = datetime.now(tz=timezone.utc)
     last_message = await channel.history(limit=1).flatten()
-    last_time = last_message[0].created_at.replace(tzinfo=timezone.utc)
-    wait_time = timedelta(minutes=wait_minutes)
-    delta = now_time - last_time
 
-    if delta > wait_time:
-        await channel.send(embed=embed)
+    if not last_message[0].author.bot:
+        now_time = datetime.now(tz=timezone.utc)
+        last_time = last_message[0].created_at.replace(tzinfo=timezone.utc)
+        wait_time = timedelta(minutes=wait_minutes)
+        delta = now_time - last_time
+
+        if delta > wait_time:
+            await channel.send(embed=embed)

--- a/lib/bot/idle_reminder.py
+++ b/lib/bot/idle_reminder.py
@@ -1,0 +1,29 @@
+from datetime import datetime, timedelta, timezone
+
+# TODO: Add an embed argument
+async def idle_reminder(channel, wait_minutes=5):
+    """
+    Checks if 'channel' has been idle for more than 'wait_minutes'
+    minutes. If so, sends an embed to that channel.
+
+    Args:
+        channel (TextChannel): Which channel to check.
+        wait_minutes (int): Check this many minutes since last message passed.
+        embed (embed): An embed object to send
+
+    Returns:
+        None
+    """
+    print("Running idle_reminder()")
+
+    now_time = datetime.now(tz=timezone.utc)
+    last_message = await channel.history(limit=1).flatten()
+    last_time = last_message[0].created_at.replace(tzinfo=timezone.utc)
+    wait_time = timedelta(minutes=wait_minutes)
+    delta = now_time - last_time
+
+    if delta > wait_time:
+        # await channel.send(embed = embed)
+        await channel.send("More than " + str(wait_time.seconds) +
+                           " seconds has passed " +
+                           "since the last message has been sent.")


### PR DESCRIPTION
Post an embed to remind people how to ask a good question when a help channel is idle for a certain amount of time. This can be integrated into the available/occupied channels. For example, the message can be posted when a channel becomes available.